### PR TITLE
Add a variable to allow fine-tuning of the length of a PathMesh3D

### DIFF
--- a/addons/PathMesh3D/src/path_mesh_3d.hpp
+++ b/addons/PathMesh3D/src/path_mesh_3d.hpp
@@ -48,6 +48,9 @@ public:
     void set_warp_along_curve(uint64_t p_surface_idx, bool p_warp);
     bool get_warp_along_curve(uint64_t p_surface_idx) const;
 
+    void set_mesh_length_offset(uint64_t p_surface_idx, real_t p_mesh_length_offset);
+    real_t get_mesh_length_offset(uint64_t p_surface_idx) const;
+
     void set_sample_cubic(uint64_t p_surface_idx, bool p_cubic);
     bool get_sample_cubic(uint64_t p_surface_idx) const;
 
@@ -87,6 +90,7 @@ private:
         bool tilt = true;
         Vector2 offset = Vector2();
         uint64_t n_tris = 0;
+        real_t mesh_length_offset = 0.0;
     };
     LocalVector<SurfaceData> surfaces;
 


### PR DESCRIPTION
There is currently no way to customize the length of a PathMesh3D's mesh so if the mesh doesn't quite line up, the result might not look so good (unless I've totally missed something).

See below where this fence mesh's posts don't go straight down so the connecting wood parts don't like up with the pole of the next mesh in the path.
<img width="799" height="499" alt="fence_bad" src="https://github.com/user-attachments/assets/2e38aabf-3103-4b63-b476-2190a74b91d3" />

This pull request adds a variable called `mesh_length_offset` that allows increasing or decreasing the distance between meshes so it can be fine-tuned in the editor.

See below where I've decreased mesh_length_offset to make the fence mesh line up correctly.
<img width="764" height="474" alt="fence_good" src="https://github.com/user-attachments/assets/7d4f91c4-87c4-4c02-89c4-998311ff5c14" />


I'm not great at C++ but hopefully this PR looks okay.
The one thing I can spot that might not be efficient is the `mesh_length_offset = surf.mesh_length_offset;` line being in the for loop. Probably not *terrible* but I might need a little hand if you consider it a problem as my C++ skills are limited.