### PR TITLE
fix macOS build

### DIFF
--- a/addons/PathMesh3D/SConstruct
+++ b/addons/PathMesh3D/SConstruct
@@ -34,9 +34,7 @@ if env["target"] in ["editor", "template_debug"]:
 
 if env["platform"] == "macos":
     library = env.SharedLibrary(
-        bin_folder + "{}.{}.{}.framework/{}.{}.{}".format(
-            lib_name, env["platform"], env["target"], lib_name, env["platform"], env["target"]
-        ),
+        bin_folder + "{}.{}.{}.dylib".format(lib_name, env["platform"], env["target"]),
         source=sources,
     )
 else:

--- a/addons/PathMesh3D/path_mesh_3d.gdextension
+++ b/addons/PathMesh3D/path_mesh_3d.gdextension
@@ -6,8 +6,8 @@ reloadable = true
 
 [libraries]
 
-macos.debug = "res://addons/PathMesh3D/bin/path_mesh_3d.macos.template_debug.framework"
-macos.release = "res://addons/PathMesh3D/bin/path_mesh_3d.macos.template_release.framework"
+macos.debug = "res://addons/PathMesh3D/bin/libpath_mesh_3d.macos.template_debug.dylib"
+macos.release = "res://addons/PathMesh3D/bin/libpath_mesh_3d.macos.template_release.dylib"
 ios.debug = "res://addons/PathMesh3D/bin/path_mesh_3d.ios.template_debug.xcframework"
 ios.release = "res://addons/PathMesh3D/bin/path_mesh_3d.ios.template_release.xcframework"
 windows.debug.x86_32 = "res://addons/PathMesh3D/bin/path_mesh_3d.windows.template_debug.x86_32.dll"


### PR DESCRIPTION
Related to https://github.com/iiMidknightii/PathMesh3D/issues/21

Before, compiling from source and trying to use the plugin on macOS would result in the following error:
<img width="833" height="140" alt="before" src="https://github.com/user-attachments/assets/94f53c99-bd70-44b5-8de2-869898f46456" />

(the built library would end up in `addons/PathMesh3D/bin/path_mesh_3d.macos.template_debug.framework/libpath_mesh_3d.macos.template_debug`)

Now it works properly:
<img width="1552" height="987" alt="after" src="https://github.com/user-attachments/assets/99ff7908-797d-439e-9c37-fc305b88638e" />
