### PR TITLE
Change macOS arch to “universal” in github actions

### DIFF
--- a/.github/workflows/build-addon.yml
+++ b/.github/workflows/build-addon.yml
@@ -74,7 +74,7 @@ jobs:
             arch: x86_64
           - os: macos-latest
             platform: macos
-            arch: x86_64
+            arch: universal
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
A tiny tweak that allows building a binary that runs natively on both Apple silicon and Intel-based Macs.

```sh
file ./addons/PathMesh3D/bin/*.dylib
./addons/PathMesh3D/bin/libpath_mesh_3d.macos.template_debug.dylib:   Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit dynamically linked shared library x86_64] [arm64:Mach-O 64-bit dynamically linked shared library arm64]
./addons/PathMesh3D/bin/libpath_mesh_3d.macos.template_debug.dylib (for architecture x86_64):	Mach-O 64-bit dynamically linked shared library x86_64
./addons/PathMesh3D/bin/libpath_mesh_3d.macos.template_debug.dylib (for architecture arm64):	Mach-O 64-bit dynamically linked shared library arm64
./addons/PathMesh3D/bin/libpath_mesh_3d.macos.template_release.dylib: Mach-O universal binary with 2 architectures: [x86_64:Mach-O 64-bit dynamically linked shared library x86_64] [arm64:Mach-O 64-bit dynamically linked shared library arm64]
./addons/PathMesh3D/bin/libpath_mesh_3d.macos.template_release.dylib (for architecture x86_64):	Mach-O 64-bit dynamically linked shared library x86_64
./addons/PathMesh3D/bin/libpath_mesh_3d.macos.template_release.dylib (for architecture arm64):	Mach-O 64-bit dynamically linked shared library arm64
```

Here is a link to a manually triggered build to prove that it properly works: https://github.com/evgenykochetkov/PathMesh3D/actions/runs/20071087951/job/57573746112#step:7:9

Also, you may need to point the users to this page: https://docs.godotengine.org/en/stable/tutorials/export/running_on_macos.html#app-is-not-signed-executable-is-linker-signed

Basically, to get rid of this error
<img width="372" height="388" alt="error" src="https://github.com/user-attachments/assets/e78c5737-a60d-4431-bdb4-984858c18b31" />
the user may need to run 
```sh
xattr -dr com.apple.quarantine ./addons/PathMesh3D/bin/*.dylib
```
from the project root.