### PR TITLE
Hardens surface access for conditions where the surface size is zero …

### DIFF
--- a/addons/PathMesh3D/src/path_tools/path_mesh_3d.cpp
+++ b/addons/PathMesh3D/src/path_tools/path_mesh_3d.cpp
@@ -440,6 +440,10 @@ void PathMesh3D::_rebuild_mesh() {
     if (mesh_l == 0.0 || baked_l < mesh_l) {
         return;
     }
+
+    ERR_FAIL_COND_EDMSG(source_mesh->get_surface_count() != surfaces.size(),
+                          "The number of surfaces in the source mesh does not "
+                          "match the number of configured surfaces.");
     
     for (uint64_t idx_surf = 0; idx_surf < source_mesh->get_surface_count(); ++idx_surf) {
         SurfaceData &surf = surfaces[idx_surf];
@@ -669,6 +673,12 @@ double PathMesh3D::_get_mesh_length() const {
         double min_z = 0;
         double max_z = 0;
         real_t mesh_length_offset = 0.0;
+
+        ERR_FAIL_COND_V_EDMSG(source_mesh->get_surface_count() != surfaces.size(),
+                          0.0,
+                          "The number of surfaces in the source mesh does not "
+                          "match the number of configured surfaces.");
+
         for (uint64_t idx_surf = 0; idx_surf < source_mesh->get_surface_count(); ++idx_surf) {
             SurfaceData surf = surfaces[idx_surf];
 


### PR DESCRIPTION
…and mesh size is not. Fixes fatal crash in #37 but does not resolve issue for why the surfaces are out of sync to begin with. I believe the problem is related to the mesh resource and whether it is local to the scene or not.

Unfortunately, I haven't been able to narrow down the root cause. It involves having two scenes, and some combination of mesh references between those scenes.